### PR TITLE
allow embeds to set appLanguage

### DIFF
--- a/src/livecodes/core.ts
+++ b/src/livecodes/core.ts
@@ -4091,8 +4091,9 @@ const configureToolsPane = (
 };
 
 const loadI18n = async (appLanguage: AppLanguage | undefined) => {
-  const userLang = appLanguage || (navigator.language as AppLanguage);
-  if (isEmbed || !userLang || userLang.toLowerCase().startsWith('en')) return;
+  const userLang =
+    appLanguage && appLanguage !== 'auto' ? appLanguage : (navigator.language as AppLanguage);
+  if ((isEmbed && !appLanguage) || !userLang || userLang.toLowerCase().startsWith('en')) return;
 
   setConfig({ ...getConfig(), appLanguage: userLang });
   const i18nModule: typeof import('./i18n/i18n') = await import(baseUrl + '{{hash:i18n.js}}');

--- a/src/livecodes/i18n/utils.ts
+++ b/src/livecodes/i18n/utils.ts
@@ -446,7 +446,7 @@ export const dispatchTranslationEvent = (elem: HTMLElement) => {
 };
 
 export const localizedAppLanguage: {
-  [key in AppLanguage]: string;
+  [key in Exclude<AppLanguage, 'auto'>]: string;
 } = {
   en: 'English',
   'zh-CN': '中文（简体）',

--- a/src/sdk/models.ts
+++ b/src/sdk/models.ts
@@ -1673,7 +1673,7 @@ export interface BlocklyContent {
   js?: string;
 }
 
-export type AppLanguage = 'en' | 'ar' | 'zh-CN';
+export type AppLanguage = 'auto' | 'en' | 'ar' | 'zh-CN';
 
 export interface User {
   uid: string;


### PR DESCRIPTION
This PR allows embeds to use i18n if `appLanguage` is explicitly set, either to a language code or to `'auto'`